### PR TITLE
Bump sauce-connect-launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/webdriverio/wdio-sauce-service#readme",
   "dependencies": {
     "request": "^2.67.0",
-    "sauce-connect-launcher": "^0.13.0"
+    "sauce-connect-launcher": "^0.15.1"
   },
   "devDependencies": {
     "babel": "^5.8.23",


### PR DESCRIPTION
sauce-connect-launcher@0.13.0 is failing for me when I run it through wdio. Updating to 0.15.1, which installs the latest sauce connect binary resolves the issue.
