### PR TITLE
Remove hardcoded sauce connect port

### DIFF
--- a/lib/sauce-launch-service.js
+++ b/lib/sauce-launch-service.js
@@ -9,13 +9,13 @@ class SauceLaunchService {
             return
         }
 
-        config.host = 'localhost'
-        config.port = 4445
-
         this.sauceConnectOpts = Object.assign({
             username: config.user,
             accessKey: config.key
         }, config.sauceConnectOpts)
+
+        config.host = 'localhost'
+        config.port = this.sauceConnectOpts.port || 4445
 
         return new Promise((resolve, reject) => SauceConnectLauncher(this.sauceConnectOpts, (err, sauceConnectProcess) => {
             if (err) {


### PR DESCRIPTION
In `wdio.conf.js`:

```
{
  sauceConnectOpts: {
    port: 4446,
  }
}
```

Will cause the tests to fail with `ERROR: Couldn't connect to selenium server`.  This is because `wdio-sauce-service` hardcodes the `port` to be 4445.

This PR fixes the issue by honoring the `port` specified in `sauceConnectOpts`.

@christian-bromann 
