### PR TITLE
chore(package): Update sauce-connect-launcher to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/webdriverio/wdio-sauce-service#readme",
   "dependencies": {
     "request": "^2.67.0",
-    "sauce-connect-launcher": "^0.15.1"
+    "sauce-connect-launcher": "^1.1.1"
   },
   "devDependencies": {
     "babel": "^5.8.23",


### PR DESCRIPTION
Specifically I'd like to use the `conectRetries` option to automagically retry when the tunnel fails to open. 

The reason for the major bump is removed support for node 10 and 12. See https://github.com/bermi/sauce-connect-launcher#changelog. I've tested locally, and everything seems to work fine :)