### PR TITLE
Update tunnelIdentifier in capabilities

### DIFF
--- a/lib/sauce-launch-service.js
+++ b/lib/sauce-launch-service.js
@@ -4,7 +4,7 @@ class SauceLaunchService {
     /**
      * modify config and launch sauce connect
      */
-    onPrepare (config) {
+    onPrepare (config, capabilities) {
         if (!config.sauceConnect) {
             return
         }
@@ -16,6 +16,14 @@ class SauceLaunchService {
 
         config.host = 'localhost'
         config.port = this.sauceConnectOpts.port || 4445
+
+        const sauceConnectTunnelIdentifier = this.sauceConnectOpts.tunnelIdentifier
+
+        if (sauceConnectTunnelIdentifier) {
+            capabilities.forEach((capability) => {
+                capability.tunnelIdentifier = sauceConnectTunnelIdentifier
+            })
+        }
 
         return new Promise((resolve, reject) => SauceConnectLauncher(this.sauceConnectOpts, (err, sauceConnectProcess) => {
             if (err) {


### PR DESCRIPTION
If a `tunnelIdentifier` is set in `sauceConnectOpts`, the same `tunnelIdentifier` needs to be set for each capability.  Otherwise, the tests fail. 

This PR updates `lib/sauce-launch-service.js` so that `tunnelIdentifier` is set for each capability if one was set in `sauceConnectOpts`