### PR TITLE
Failing suites in mocha tests now mark saucelabs job as failed

### DIFF
--- a/lib/sauce-service.js
+++ b/lib/sauce-service.js
@@ -41,6 +41,12 @@ class SauceService {
         global.browser.execute('sauce:context=' + test.parent + ' - ' + test.title)
     }
 
+    afterSuite (suite) {
+        if (suite.hasOwnProperty('err')) {
+            ++this.failures
+        }
+    }
+	
     afterTest (test) {
         if (!test.passed) {
             ++this.failures


### PR DESCRIPTION
This is to fix a problem that we had where tests that were failing were marked as passed in SauceLabs.

Given a test that looked like this:
```js
describe('Login: Successful with a verfied user', () => {
	describe('Given I have something', () => {
		it('should be like that', () => {
		});
		describe('When I do something', () => {			
			it('should  be done', () => {
			});
		});
	});	
});
```
The first 'describe' line would be used as the title for the test in SauceLabs. This is treat as a suite by the sauce service.

The two 'it's' would be used as a test as they also contain an assertion. If the first 'it' passes but then the test fails in the next describe loop (due to an element not being found etc.), it never then reaches the 2nd 'it'. Which means on the terminal the test has failed but in SauceLabs its marked as passed.

I've added an afterSuite function to check to see if the suite contains an error then to mark the job as failed. Just as the functionality already exists for the type 'feature' in the same file.