### PR TITLE
Update hooks to adhere to cucmber v3 conventions

### DIFF
--- a/lib/sauce-service.js
+++ b/lib/sauce-service.js
@@ -58,12 +58,12 @@ class SauceService {
             return
         }
 
-        this.suiteTitle = feature.getName()
+        this.suiteTitle = feature.name
         global.browser.execute('sauce:context=Feature: ' + this.suiteTitle)
     }
 
     afterStep (feature) {
-        if (feature.getFailureException()) {
+        if (feature.failureException) {
             ++this.failures
         }
     }
@@ -73,7 +73,7 @@ class SauceService {
             return
         }
 
-        global.browser.execute('sauce:context=Scenario: ' + scenario.getName())
+        global.browser.execute('sauce:context=Scenario: ' + scenario.name)
     }
 
     /**


### PR DESCRIPTION
In cucumber v3, the structure of the feature/scenario objects changed,
resultining in TypeErrors as the functions were no longer defined
(or valid).

Closes #35