### PR TITLE
Update sauce-connect-launcher to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5205,9 +5205,9 @@
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "sauce-connect-launcher": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.2.tgz",
-      "integrity": "sha1-c0bMj73EQxkTI0ObBzNFH181IfI=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/sauce-connect-launcher/-/sauce-connect-launcher-1.2.3.tgz",
+      "integrity": "sha1-0vkxrXro/avxlopEDnsgQXrKf4Y=",
       "requires": {
         "adm-zip": "0.4.7",
         "async": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/webdriverio/wdio-sauce-service#readme",
   "dependencies": {
     "request": "2.81.0",
-    "sauce-connect-launcher": "1.2.2"
+    "sauce-connect-launcher": "1.2.3"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",


### PR DESCRIPTION
### What
Update sauce-connect-launcher to 1.2.3

### Why
Add support for single-letter Sauce Conenct flags

### Who
@christian-bromann @khirakawa @prshreshtha @djgrant @janmeier 
Can you please be so kind and release 0.4.2 with this change?

### Context
https://github.com/bermi/sauce-connect-launcher/pull/134/files