### PR TITLE
Ability to detect step failure for cucumber v3 and v4

### DIFF
--- a/lib/sauce-service.js
+++ b/lib/sauce-service.js
@@ -75,7 +75,11 @@ class SauceService {
             /**
              * Cucumber v2
              */
-            (typeof feature.getFailureException === 'function' && feature.getFailureException())
+            (typeof feature.getFailureException === 'function' && feature.getFailureException()) ||
+            /**
+             * Cucumber v3, v4
+             */
+            (feature.status === 'failed')
         ) {
             ++this.failures
         }


### PR DESCRIPTION
Hello,

The cucumber API has changed again on v3, thus sauce plugin is currently enable to detect failures when using wdio-cucumber-framework v2.x (which upgrades from cucumber v2 to v3-v4).
This fixes that problem by adding the proper failure condition.