### PR TITLE
stash

### DIFF
--- a/lib/sauce-service.js
+++ b/lib/sauce-service.js
@@ -110,12 +110,30 @@ class SauceService {
     /**
      * update Sauce Labs job
      */
-    after () {
+    after (result) {
         if (!this.sauceUser || !this.sauceKey) {
             return
         }
+        let failures = this.failures
 
-        return this.updateJob(this.sessionId, this.failures)
+        /**
+         * set failures if user has bail option set in which case afterTest and
+         * afterSuite aren't executed before after hook
+         */
+        if (global.browser.config.mochaOpts && global.browser.config.mochaOpts.bail && Boolean(result)) {
+            failures = 1
+        }
+
+        // const status = 'status: ' + (failures > 0 ? 'failing' : 'passing')
+        if (!global.browser.isMultiremote) {
+            // log.info(`Update job with sessionId ${global.browser.sessionId}, ${status}`)
+            return this.updateJob(global.browser.sessionId, failures)
+        }
+
+        return Promise.all(Object.keys(this.capabilities).map((browserName) => {
+            // log.info(`Update multiremote job for browser "${browserName}" and sessionId ${global.browser[browserName].sessionId}, ${status}`)
+            return this.updateJob(global.browser[browserName].sessionId, failures, false, browserName)
+        }))
     }
 
     onReload (oldSessionId, newSessionId) {


### PR DESCRIPTION
First attempt to port https://github.com/webdriverio/webdriverio/pull/3158/commits/a6ff45a5b09b2962f5680b16532243e615beebf2 back to v4, not sure what to do about the logger methods as the old service was not using that?  Also getting an undefined error

․TypeError: Cannot read property 'mochaOpts' of undefined
at SauceService.after (/Users/pmerwin/Projects/qa/NWDIO/lib-webdriverio-nodejs/node_modules/wdio-sauce-service/build/sauce-service.js:132:34)
at execHook (/Users/pmerwin/Projects/qa/NWDIO/lib-webdriverio-nodejs/node_modules/wdio-sync/build/index.js:162:35)

